### PR TITLE
自動ビルド用ワークフロー追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,11 @@ jobs:
             -p:PublishSingleFile=true \
             -p:EnableWindowsTargeting=true \
             --self-contained ${{ matrix.standalone }}
+      - name: Copy Necessary Files
+        run: |
+          cp -r ./exe/Image ./out/
+          cp -r ./exe/Sound ./out/
+          cp -r ./exe/TSV ./out/
       - name: Zip binaries
         run: |
           cd out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,120 @@
+name: Build
+on:
+  push: { }
+
+env:
+  APP_NAME: ${{ github.event.repository.name }}
+  NAMESPACE: "TatehamaInterlockingConsole"
+  TZ: "Asia/Tokyo"
+
+jobs:
+  calc_version:
+    runs-on: ubuntu-latest
+    name: "Calc Version"
+    outputs:
+      VERSION: ${{ steps.calc_version.outputs.VERSION }}
+    steps:
+      - name: Get latest release
+        id: latest_release
+        uses: actions/github-script@v7.0.1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          script: |
+            try {
+              const response = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+              return response.data.tag_name;
+            }
+            catch (e){
+              if (e.status === 404) {
+                return '';
+              } else {
+                throw e;
+              }
+            }
+      - name: Calculate Version
+        id: calc_version
+        run: |
+          latest_tag="${{ steps.latest_release.outputs.result }}"
+          if [ -n "${latest_tag}" ]; then
+            today=$(date +%Y%m%d)
+            if [[ $latest_tag == *$today* ]]; then
+              n=$(echo $latest_tag | awk -F. '{print $4}')
+              n=$((n + 1))
+            else
+              n=1
+            fi
+            VERSION="v1.0.${today}.${n}-beta"
+          else
+            VERSION=$(date +%Y%m%d%H%M%S)
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+  build:
+    runs-on: ubuntu-latest
+    name: "Build"
+    needs: calc_version
+    strategy:
+      matrix:
+        standalone: [ true, false ]
+        # 接続先をProdにしたバージョンを作成する場合は、リストにfalseを追加する
+        dev: [ true ]
+    steps:
+      - name: Set Zip File Name
+        # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
+        run: |
+          version=$(echo "${{ needs.calc_version.outputs.VERSION }}" | sed 's/\./_/')
+          echo "ZIP_FILE_NAME=${{ env.APP_NAME }}_${version}${{ (matrix.dev && '-dev') || ''}}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Write ServerAddress.cs
+        run: |
+          if [ "${{ matrix.dev }}" = "true" ]; then
+            SERVER_ADDRESS=${{ secrets.SERVER_ADDRESS_DEV }}
+          else
+            SERVER_ADDRESS=${{ secrets.SERVER_ADDRESS }}
+          fi
+          echo "namespace ${{ env.NAMESPACE }}; public static class ServerAddress { public const string SignalAddress = \"${SERVER_ADDRESS}\"; }" > ./ServerAddress.cs
+      - name: Setup dotnet 8.0.x
+        uses: actions/setup-dotnet@v4.3.1
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build Exe
+        run: |
+          dotnet publish -c Release \
+            -o ./out \
+            -r win-x64 \
+            -p:PublishSingleFile=true \
+            -p:EnableWindowsTargeting=true \
+            --self-contained ${{ matrix.standalone }}
+      - name: Zip binaries
+        run: |
+          cd out
+          zip -r ../${{ env.ZIP_FILE_NAME }} .
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          path: ./${{ env.ZIP_FILE_NAME }}
+          name: ${{ env.ZIP_FILE_NAME }}
+  create_new_release:
+    runs-on: ubuntu-latest
+    name: "Create New Release"
+    permissions:
+      contents: write
+    needs:
+      - calc_version
+      - build
+    steps:
+      - name: Download Artifact
+        uses: actions/download-artifact@v4.2.1
+        with:
+          path: 'out'
+          merge-multiple: 'true'
+      - name: Create New Release
+        id: create_release
+        uses: softprops/action-gh-release@v2.2.1
+        with:
+          tag_name: ${{ needs.calc_version.outputs.VERSION }}
+          make_latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          files: out/* 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
           else
             SERVER_ADDRESS=${{ secrets.SERVER_ADDRESS }}
           fi
-          echo "namespace ${{ env.NAMESPACE }}; public static class ServerAddress { public const string SignalAddress = \"${SERVER_ADDRESS}\"; }" > ./ServerAddress.cs
+          echo "namespace ${{ env.NAMESPACE }}; public static class ServerAddress { public const string SignalAddress = \"${SERVER_ADDRESS}\"; }" > ./TatehamaInterlockingConsole/ServerAddress.cs
       - name: Setup dotnet 8.0.x
         uses: actions/setup-dotnet@v4.3.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
             else
               n=1
             fi
-            VERSION="v1.0.${today}.${n}-beta"
+            VERSION="${today}_${n}"
           else
             VERSION=$(date +%Y%m%d%H%M%S)
           fi
@@ -64,7 +64,7 @@ jobs:
       - name: Set Zip File Name
         # ZIP_FILE_NAMEは、ビルドしたアプリケーションのファイル名を指定するための環境変数。ソフトによって変えると良さげ
         run: |
-          version=$(echo "${{ needs.calc_version.outputs.VERSION }}" | sed 's/\./_/')
+          version=$(echo "${{ needs.calc_version.outputs.VERSION }}" | sed 's/\./_/g')
           echo "ZIP_FILE_NAME=${{ env.APP_NAME }}_${version}${{ (matrix.dev && '-dev') || ''}}${{ (matrix.standalone && '-standalone') || '' }}.zip" >> $GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
# 仕様
mainにPushした場合、以下のようにYYYYmmdd_nで、latest_releaseでリリースされる
https://github.com/Kesigomon/TatehamaInterlockingConsole/releases/tag/20250413_1

main以外にPushした場合、以下のようにYYYYmmddHHMMSS 形式でリリースされる(latest_releaseにはならない)
https://github.com/Kesigomon/TatehamaInterlockingConsole/releases/tag/20250413073412

`-dev` が dev環境アドレスのバイナリ(ついてないのはProd環境へのバイナリ)、`-standalone` は .NET Core 8.0 Runtimeなしでも動くバージョン(逆に、ついてないバージョンは .NET Core 8.0 Runtimeが必要になる)

# 必須シークレット
`SERVER_ADDRESS_DEV` => Dev環境のサーバーアドレス
`SERVER_ADDRESS` => Prod環境のサーバーアドレス


設定方法は以下参照
https://docs.github.com/ja/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository